### PR TITLE
Loop1 loop2 optimisation

### DIFF
--- a/HMMextra0s/src/Makefile.Mahuika
+++ b/HMMextra0s/src/Makefile.Mahuika
@@ -3,7 +3,7 @@
 # installing this package on Mahuika
 
 FC = ifort
-FCFLAGS = -fPIC -O2
+FCFLAGS = -fPIC -Ofast
 LDFLAGS = -shared
 
 HMMextra0s.so : loop1.o loop2.o

--- a/HMMextra0s/src/Makefile.Mahuika
+++ b/HMMextra0s/src/Makefile.Mahuika
@@ -1,0 +1,18 @@
+# Makefile for the Intel Fortran compiler
+# Rename this file to "Makefile" when
+# installing this package on Mahuika
+
+FC = ifort
+FCFLAGS = -fPIC -O2
+LDFLAGS = -shared
+
+HMMextra0s.so : loop1.o loop2.o
+	$(FC) -o $@ $(FCFLAGS) $+ $(LDFLAGS)
+
+%.o : %.f
+	$(FC) -c $(FCFLAGS) $<
+
+clean :
+	rm -f *.o *.so
+
+.PHONY : clean


### PR DESCRIPTION
Hi Ting,

Here is a first pull request with the following improvements to the Fortran code:

- Added Makefile for Intel Fortran compiler - this provides almost x1.7 (hmm2dtest) - x2 (hmm1dtest) speedup over GNU Fortran for the Fortran code, and just over 6% - 8% overall performance improvement for the two test cases
- Split main loops in loop1.f and loop2.f to improve memory access and vectorisation - improves Fortran code performance by around 12% (overall performance improvement is less)
- Replaced "do while" loops with plain "do" loops to help compiler optimisation