### PR TITLE
 vectorised the hatgamma expression

### DIFF
--- a/HMMextra0s/R/hmm0norm.R
+++ b/HMMextra0s/R/hmm0norm.R
@@ -109,15 +109,7 @@ function( R, Z, pie, gamma, mu, sig, delta, tol=1e-6, print.level=1, fortran = T
                     sum( v[Z==1,j] ) ) }
 ###Estimate gamma_{ij}
 #
-   hatgamma <- matrix( 1, m, m )
-   for (j in 1:m)
-   {
-      for (i in 1:m)
-      {
-         hatgamma[i,j] <- sum( (w[,i,j]) ) / 
-                          ( sum( v[,i] ) - v[nn,i] )
-      }
-   }
+    hatgamma <- colSums( w ) / replicate(m, colSums( v ) - v[nn,])
 #
 ###Estimate delta
     hatdelta <- v[1,]


### PR DESCRIPTION
Hi @athenatingwang 

This branch vectorises the computation of hatgamma in hmm0norm.R. The two nested loops are replaced with a single R expression. Easier to maintain and expect +20% speed improvement. 