### PR TITLE
Implementation of M-step in Fortran

### DIFF
--- a/HMMextra0s/R/hmm0norm.R
+++ b/HMMextra0s/R/hmm0norm.R
@@ -99,14 +99,25 @@ function( R, Z, pie, gamma, mu, sig, delta, tol=1e-6, print.level=1, fortran = T
 #
 ##M-step
 ###Estimate pie_{i}, mu_{ij} and sigma_{ij}
-    hatpie <- NULL
+    hatpie <- rep(0, m)
     hatmu <- matrix( 0, n, m )
     hatsig <- matrix( 0, n, m )
-    for (j in 1:m)
-    { hatpie[j] <- ( v[,j] %*% Z ) / sum( v[,j] )
-      hatmu[,j] <- ( v[Z==1,j] %*% R[Z==1,] ) / sum( v[Z==1,j] )
-      hatsig[,j] <- sqrt( ( v[Z==1,j] %*% ( t(t(R[Z==1,]) - hatmu[,j]) )^2 ) / 
-                    sum( v[Z==1,j] ) ) }
+    if (fortran!=TRUE){
+        for (j in 1:m) {
+            hatpie[j] <- ( v[,j] %*% Z ) / sum( v[,j] )
+            hatmu[,j] <- ( v[Z==1,j] %*% R[Z==1,] ) / sum( v[Z==1,j] )
+            hatsig[,j] <- sqrt( ( v[Z==1,j] %*% ( t(t(R[Z==1,]) - hatmu[,j]) )^2 ) /
+                                sum( v[Z==1,j] ) )
+        }
+    } else {
+        mstep1d <- .Fortran("mstep1d", n, m, nn, v, Z, R,
+                            hatpie, hatmu, hatsig,
+                            PACKAGE="HMMextra0s")
+        hatpie <- mstep1d[[7]]
+        hatmu <- mstep1d[[8]]
+        hatsig <- mstep1d[[9]]
+    }
+
 ###Estimate gamma_{ij}
 #
    hatgamma <- matrix( 1, m, m )

--- a/HMMextra0s/R/hmm0norm.R
+++ b/HMMextra0s/R/hmm0norm.R
@@ -102,7 +102,7 @@ function( R, Z, pie, gamma, mu, sig, delta, tol=1e-6, print.level=1, fortran = T
     hatpie <- rep(0, m)
     hatmu <- matrix( 0, n, m )
     hatsig <- matrix( 0, n, m )
-    if (fortran!=TRUE){
+    if (fortran!=TRUE) {
         for (j in 1:m) {
             hatpie[j] <- ( v[,j] %*% Z ) / sum( v[,j] )
             hatmu[,j] <- ( v[Z==1,j] %*% R[Z==1,] ) / sum( v[Z==1,j] )

--- a/HMMextra0s/src/HMMextra0s_init.c
+++ b/HMMextra0s/src/HMMextra0s_init.c
@@ -13,10 +13,13 @@ extern void F77_NAME(loop2)(int *m, int *T, double *phi, double *pRS, double *ga
 
 extern void F77_NAME(mstep1d)(int *n, int *m, int *nn, double *v, double *Z, double *R, double *hatpie, double *hatmu, double *hatsig);
 
+extern void F77_NAME(mstep2d)(int *n, int *m, int *nn, double *v, double *Z, double *R, double *hatpie, double *hatmu, double *hatsig);
+
 static const R_FortranMethodDef FortranEntries[] = {
     {"loop1", (DL_FUNC) &F77_NAME(loop1), 8},
     {"loop2", (DL_FUNC) &F77_NAME(loop2), 8},
     {"mstep1d", (DL_FUNC) &F77_NAME(mstep1d), 9},
+    {"mstep2d", (DL_FUNC) &F77_NAME(mstep2d), 9},
     {NULL, NULL, 0}
 };
 

--- a/HMMextra0s/src/HMMextra0s_init.c
+++ b/HMMextra0s/src/HMMextra0s_init.c
@@ -11,9 +11,12 @@ extern void F77_NAME(loop1)(int *m, int *T, double *phi, double *pRS, double *ga
 
 extern void F77_NAME(loop2)(int *m, int *T, double *phi, double *pRS, double *gamma, double *logbet, double *lscale, double *tmp);
 
+extern void F77_NAME(mstep1d)(int *n, int *m, int *nn, double *v, double *Z, double *R, double *hatpie, double *hatmu, double *hatsig);
+
 static const R_FortranMethodDef FortranEntries[] = {
     {"loop1", (DL_FUNC) &F77_NAME(loop1), 8},
     {"loop2", (DL_FUNC) &F77_NAME(loop2), 8},
+    {"mstep1d", (DL_FUNC) &F77_NAME(mstep1d), 9},
     {NULL, NULL, 0}
 };
 

--- a/HMMextra0s/src/Makefile.Mahuika
+++ b/HMMextra0s/src/Makefile.Mahuika
@@ -6,7 +6,7 @@ FC = ifort
 FCFLAGS = -fPIC -Ofast
 LDFLAGS = -shared
 
-HMMextra0s.so : loop1.o loop2.o
+HMMextra0s.so : loop1.o loop2.o mstep.o
 	$(FC) -o $@ $(FCFLAGS) $+ $(LDFLAGS)
 
 %.o : %.f90

--- a/HMMextra0s/src/mstep.f90
+++ b/HMMextra0s/src/mstep.f90
@@ -31,3 +31,39 @@ subroutine mstep1d(n, m, nn, v, Z, R, hatpie, hatmu, hatsig)
     end do
 
 end subroutine mstep1d
+
+subroutine mstep2d(n, m, nn, v, Z, R, hatpie, hatmu, hatsig)
+    ! Estimate pie_{i}, mu_{ij} and sigma_{ij}
+    implicit none
+    integer, parameter :: r8 = selected_real_kind(15, 307)
+    ! Arguments
+    integer n, m, nn
+    real(r8) v(nn,m), Z(nn), R(nn,n)
+    real(r8) hatpie(m), hatmu(m,n), hatsig(n,n,m)
+    ! Local variables
+    integer i, j, k, l
+    real(r8) vZ(nn), vdotZ, vsum
+
+    do j = 1,m
+
+        vsum = 0.0_r8
+        vdotZ = 0.0_r8
+        ! We assume here that Z(i) is element of {0.0,1.0}
+        do i = 1,nn
+            vZ(i) = v(i,j)*Z(i)
+            vsum = vsum + v(i,j)
+            vdotZ = vdotZ + vZ(i)
+        end do
+
+        hatpie(j) = vdotZ/vsum
+
+        do k = 1,n
+            hatmu(j,k) = dot_product(vZ(:),R(:,k))/vdotZ
+            do l = 1,n
+                hatsig(k,l,j) = dot_product(vZ(:),(R(:,k)-hatmu(j,k))*(R(:,l)-hatmu(j,l)))/vdotZ
+            end do
+        end do
+
+    end do
+
+end subroutine mstep2d

--- a/HMMextra0s/src/mstep.f90
+++ b/HMMextra0s/src/mstep.f90
@@ -1,0 +1,33 @@
+subroutine mstep1d(n, m, nn, v, Z, R, hatpie, hatmu, hatsig)
+    ! Estimate pie_{i}, mu_{ij} and sigma_{ij}
+    implicit none
+    integer, parameter :: r8 = selected_real_kind(15, 307)
+    ! Arguments
+    integer n, m, nn
+    real(r8) v(nn,m), Z(nn), R(nn,n)
+    real(r8) hatpie(m), hatmu(n,m), hatsig(n,m)
+    ! Local variables
+    integer i, j, k
+    real(r8) vZ(nn), vdotZ, vsum
+
+    do j = 1,m
+
+        vsum = 0.0_r8
+        vdotZ = 0.0_r8
+        ! We assume here that Z(i) is element of {0.0,1.0}
+        do i = 1,nn
+            vZ(i) = v(i,j)*Z(i)
+            vsum = vsum + v(i,j)
+            vdotZ = vdotZ + vZ(i)
+        end do
+
+        hatpie(j) = vdotZ/vsum
+
+        do k = 1,n
+            hatmu(k,j) = dot_product(vZ(:),R(:,k))/vdotZ
+            hatsig(k,j) = sqrt(dot_product(vZ(:),(R(:,k)-hatmu(k,j))**2)/vdotZ)
+        end do
+
+    end do
+
+end subroutine mstep1d


### PR DESCRIPTION
This branch implements the "M-step" computations in Fortran, for both the 1D and 2D cases.

Runtime performance improvements on Mahuika:

1. hmm1dtest: 10%
2. hmm2dtest: 27%

**Important:** The Fortran implementation assumes that vector `Z` only contains numbers `0` and `1`, which simplifies and accelerates computation - R constructs such as `v[Z==1,j]` can then be replaced by `v(:,j)*Z(:)` in the Fortran code.