### PR TITLE
Fortran implementation of estep

### DIFF
--- a/HMMextra0s/R/hmm0norm.R
+++ b/HMMextra0s/R/hmm0norm.R
@@ -83,19 +83,31 @@ function( R, Z, pie, gamma, mu, sig, delta, tol=1e-6, print.level=1, fortran = T
     }
 #
 ##E-step
+    if (fortran!=TRUE) {
 ###Calculate v_t(j)
-    v <- exp(logalpha + logbeta - LL)
+        v <- exp(logalpha + logbeta - LL)
 ###Calculate w_t(i,j) 
-    w <- array( NA, c( nn-1, m, m ) )
-    for (k in 1:m) {
-        logprob <- log( pRS[-1, k] )
-        logPi <- matrix(log(gamma[, k]), byrow = TRUE, nrow = nn - 
-            1, ncol = m)
-        logPbeta <- matrix(logprob + logbeta[-1, k],
-            byrow = FALSE, nrow = nn - 1, ncol = m)
-        w[, , k] <- logPi + logalpha[-nn, ] + logPbeta - LL
+        w <- array( NA, c( nn-1, m, m ) )
+        for (k in 1:m) {
+            logprob <- log( pRS[-1, k] )
+            logPi <- matrix(log(gamma[, k]), byrow = TRUE, nrow = nn - 
+                1, ncol = m)
+            logPbeta <- matrix(logprob + logbeta[-1, k],
+                byrow = FALSE, nrow = nn - 1, ncol = m)
+            w[, , k] <- logPi + logalpha[-nn, ] + logPbeta - LL
+        }
+        w <- exp(w)
+    } else {
+        v <- array(0.0, c( nn, m ))
+        w <- array(0.0, c( nn-1, m, m ) )
+# logalpha can contain -Inf values where phi=0; set NAOK=TRUE as the Fortran code
+# will handle such cases safely
+        estep <- .Fortran("estep", m, nn, logalpha, logbeta, LL,
+                           pRS, gamma, v, w, NAOK=TRUE, PACKAGE="HMMextra0s")
+        v <- estep[[8]]
+        w <- estep[[9]]
     }
-    w <- exp(w)
+
 #
 ##M-step
 ###Estimate pie_{i}, mu_{ij} and sigma_{ij}

--- a/HMMextra0s/R/hmm0norm2d.R
+++ b/HMMextra0s/R/hmm0norm2d.R
@@ -90,19 +90,31 @@ hmm0norm2d <- function( R, Z, pie, gamma, mu, sig, delta, tol=1e-6, print.level=
     }
 #
 ##E-step
+    if (fortran!=TRUE) {
 ###Calculate v_t(j)
-    v <- exp(logalpha + logbeta - LL)
+        v <- exp(logalpha + logbeta - LL)
 ###Calculate w_t(i,j) 
-    w <- array( NA, c( nn-1, m, m ) )
-    for (k in 1:m) {
-        logprob <- log( pRS[-1, k] )
-        logPi <- matrix(log(gamma[, k]), byrow = TRUE, nrow = nn - 
-            1, ncol = m)
-        logPbeta <- matrix(logprob + logbeta[-1, k],
-            byrow = FALSE, nrow = nn - 1, ncol = m)
-        w[, , k] <- logPi + logalpha[-nn, ] + logPbeta - LL
+        w <- array( NA, c( nn-1, m, m ) )
+        for (k in 1:m) {
+            logprob <- log( pRS[-1, k] )
+            logPi <- matrix(log(gamma[, k]), byrow = TRUE, nrow = nn - 
+                1, ncol = m)
+            logPbeta <- matrix(logprob + logbeta[-1, k],
+                byrow = FALSE, nrow = nn - 1, ncol = m)
+            w[, , k] <- logPi + logalpha[-nn, ] + logPbeta - LL
+        }
+        w <- exp(w)
+    } else {
+        v <- array(0.0, c( nn, m ))
+        w <- array(0.0, c( nn-1, m, m ) )
+# logalpha can contain -Inf values where phi=0; set NAOK=TRUE as the Fortran code
+# will handle such cases safely
+        estep <- .Fortran("estep", m, nn, logalpha, logbeta, LL,
+                          pRS, gamma, v, w, NAOK=TRUE, PACKAGE="HMMextra0s")
+        v <- estep[[8]]
+        w <- estep[[9]]
     }
-    w <- exp(w)
+
 #
 ##M-step
 ###Estimate pie_{i}, mu_{ij} and sigma_{ij}

--- a/HMMextra0s/src/HMMextra0s_init.c
+++ b/HMMextra0s/src/HMMextra0s_init.c
@@ -11,6 +11,8 @@ extern void F77_NAME(loop1)(int *m, int *T, double *phi, double *pRS, double *ga
 
 extern void F77_NAME(loop2)(int *m, int *T, double *phi, double *pRS, double *gamma, double *logbet, double *lscale, double *tmp);
 
+extern void F77_NAME(estep)(int *m, int *nn, double *logalpha, double *logbeta, double *ll, double *pRS, double *gamma, double *v, double *w);
+
 extern void F77_NAME(mstep1d)(int *n, int *m, int *nn, double *v, double *Z, double *R, double *hatpie, double *hatmu, double *hatsig);
 
 extern void F77_NAME(mstep2d)(int *n, int *m, int *nn, double *v, double *Z, double *R, double *hatpie, double *hatmu, double *hatsig);
@@ -18,6 +20,7 @@ extern void F77_NAME(mstep2d)(int *n, int *m, int *nn, double *v, double *Z, dou
 static const R_FortranMethodDef FortranEntries[] = {
     {"loop1", (DL_FUNC) &F77_NAME(loop1), 8},
     {"loop2", (DL_FUNC) &F77_NAME(loop2), 8},
+    {"estep", (DL_FUNC) &F77_NAME(estep), 9},
     {"mstep1d", (DL_FUNC) &F77_NAME(mstep1d), 9},
     {"mstep2d", (DL_FUNC) &F77_NAME(mstep2d), 9},
     {NULL, NULL, 0}

--- a/HMMextra0s/src/Makefile.Mahuika
+++ b/HMMextra0s/src/Makefile.Mahuika
@@ -6,7 +6,7 @@ FC = ifort
 FCFLAGS = -fPIC -Ofast
 LDFLAGS = -shared
 
-HMMextra0s.so : loop1.o loop2.o mstep.o
+HMMextra0s.so : loop1.o loop2.o estep.o mstep.o
 	$(FC) -o $@ $(FCFLAGS) $+ $(LDFLAGS)
 
 %.o : %.f90

--- a/HMMextra0s/src/estep.f90
+++ b/HMMextra0s/src/estep.f90
@@ -1,0 +1,27 @@
+subroutine estep(m, nn, logalpha, logbeta, ll, pRS, gam, v, w)
+    ! Calculate v_t(j) and w_t(i,j)
+    implicit none
+    integer, parameter :: r8 = selected_real_kind(15, 307)
+    ! Arguments
+    integer m, nn
+    real(r8) logalpha(nn, m), logbeta(nn, m), ll, pRS(nn, m), gam(m,m)
+    real(r8) v(nn, m), w(nn-1, m, m)
+    ! Local variables
+    integer j, k
+    real(r8) loggamminll(m,m), logPbeta(nn-1)
+
+    loggamminll(:,:) = log(gam(:,:)) - ll
+
+    do k = 1,m
+
+        logPbeta(:) = log( pRS(2:nn,k) ) + logbeta(2:nn,k)
+        v(:,k) = exp(logalpha(:,k) + logbeta(:,k) - ll)
+
+        do j = 1,m
+            w(:,j,k) = exp(loggamminll(j,k) + logalpha(1:nn-1,j) + &
+                           logPbeta(:))
+        end do
+
+    end do
+
+end subroutine estep


### PR DESCRIPTION
Converted R code for "estep" into Fortran:

- R code is the same between 1D and 2D cases, implemented single Fortran routine ```estep```
- Innermost loops vectorised for best efficiency
- Speedup over previous optimisations x2.4 (1D) and x1.8 (2D)

Note that it is necessary to allow ```Inf``` values being passed from R to Fortran using flag ```NAOK=TRUE``` in the ```.Fortran``` call - variable ```logalpha``` can contain ```-Inf``` where ```phi=0.0```. This is handled safely by the Fortran code, where exponentiation will return ```0.0``` for ```-Inf```.