### PR TITLE
Fortran implementation of pRS computation

### DIFF
--- a/HMMextra0s/R/hmm0norm.R
+++ b/HMMextra0s/R/hmm0norm.R
@@ -9,10 +9,16 @@ function( R, Z, pie, gamma, mu, sig, delta, tol=1e-6, print.level=1, fortran = T
   {
 #
     pRS <- matrix( 1, nn, m )
-    for (k in 1:m)
-    {
-      pRS[,k] <- (pie[k] * exp( - (R[,1] - mu[,k])^2 / (2 * sig[,k]^2) ) /
-                   (sqrt(2 * pi) * sig[,k]) )^(Z) * (1-pie[k])^(1-Z)
+    if (fortran!=TRUE){
+        for (k in 1:m)
+        {
+          pRS[,k] <- (pie[k] * exp( - (R[,1] - mu[,k])^2 / (2 * sig[,k]^2) ) /
+                       (sqrt(2 * pi) * sig[,k]) )*(Z) + (1-pie[k])*(1-Z)
+        }
+    } else {
+        prsloop <- .Fortran("prsloop", m, nn, pie, R[,1], mu[1,], sig[1,], Z,
+                            pRS, PACKAGE="HMMextra0s")
+        pRS <- prsloop[[8]]
     }
 #
 ##Scaled forward variable

--- a/HMMextra0s/R/hmm0norm2d.R
+++ b/HMMextra0s/R/hmm0norm2d.R
@@ -19,7 +19,7 @@ hmm0norm2d <- function( R, Z, pie, gamma, mu, sig, delta, tol=1e-6, print.level=
     pRS <- matrix( 1, nn, m )
     for (k in 1:m)
     {
-      pRS[,k] <- ( pie[k] * dmvnorm(R, mean = mu[k,], sigma = sig[,,k]) )^Z * (1-pie[k])^(1-Z)
+      pRS[,k] <- ( pie[k] * dmvnorm(R, mean = mu[k,], sigma = sig[,,k]) )*Z + (1-pie[k])*(1-Z)
     }
 #
 ##Scaled forward variable

--- a/HMMextra0s/src/HMMextra0s_init.c
+++ b/HMMextra0s/src/HMMextra0s_init.c
@@ -7,6 +7,8 @@
 */
 
 /* .Fortran calls */
+extern void F77_NAME(prsloop)(int *m, int *nn, double *pie, double *R, double *mu, double *sig, double *Z, double *pRS);
+
 extern void F77_NAME(loop1)(int *m, int *T, double *phi, double *pRS, double *gamma, double *logalp, double *lscale, double *tmp);
 
 extern void F77_NAME(loop2)(int *m, int *T, double *phi, double *pRS, double *gamma, double *logbet, double *lscale, double *tmp);
@@ -16,6 +18,7 @@ extern void F77_NAME(mstep1d)(int *n, int *m, int *nn, double *v, double *Z, dou
 extern void F77_NAME(mstep2d)(int *n, int *m, int *nn, double *v, double *Z, double *R, double *hatpie, double *hatmu, double *hatsig);
 
 static const R_FortranMethodDef FortranEntries[] = {
+    {"prsloop", (DL_FUNC) &F77_NAME(prsloop), 8},
     {"loop1", (DL_FUNC) &F77_NAME(loop1), 8},
     {"loop2", (DL_FUNC) &F77_NAME(loop2), 8},
     {"mstep1d", (DL_FUNC) &F77_NAME(mstep1d), 9},

--- a/HMMextra0s/src/Makefile.Mahuika
+++ b/HMMextra0s/src/Makefile.Mahuika
@@ -6,7 +6,7 @@ FC = ifort
 FCFLAGS = -fPIC -Ofast
 LDFLAGS = -shared
 
-HMMextra0s.so : loop1.o loop2.o mstep.o
+HMMextra0s.so : prsloop.o loop1.o loop2.o estep.o mstep.o
 	$(FC) -o $@ $(FCFLAGS) $+ $(LDFLAGS)
 
 %.o : %.f90

--- a/HMMextra0s/src/prsloop.f90
+++ b/HMMextra0s/src/prsloop.f90
@@ -1,0 +1,24 @@
+subroutine prsloop(m, nn, pie, R, mu, sig, Z, pRS)
+    implicit none
+    integer, parameter :: r8 = selected_real_kind(15, 307)
+    ! sqrt(2*pi)
+    real(r8), parameter :: sqrt2pi = sqrt(8.0_r8 * atan(1.0_r8))
+    ! Arguments
+    integer m, nn
+    real(r8) pie(m), R(nn), mu(m), sig(m), Z(nn)
+    real(r8) pRS(nn,m)
+    ! Local variables
+    integer j, k
+    real(r8) oneminpie, fac1, fac2, deltaR
+
+    do k = 1,m
+        oneminpie = 1.0_r8-pie(k)
+        fac1 = pie(k)/(sqrt2pi*sig(k))
+        fac2 = -1.0_r8/(2.0_r8*sig(k)*sig(k))
+        do j = 1,nn
+            deltaR = R(j) - mu(k)
+            pRS(j,k) = (fac1*exp(fac2*deltaR*deltaR))*Z(j) + oneminpie*(1.0_r8-Z(j))
+        end do
+    end do
+
+end subroutine prsloop


### PR DESCRIPTION
**Please consider this pull request after the estep pull request to make sure that ```Makefile.Mahuika``` remains consistent**

Converted R code for ```pRS``` computation in 1D into Fortran:
- Innermost loops vectorised for best efficiency
- Speedup over previous optimisations x1.3
- Replaced ```^Z``` expressions with ```*Z``` in R version of ```pRS``` computation - this has the same effect but is less computationally expensive

Small improvement in 2D code:
- Replaced ```^Z``` expressions with ```*Z``` in ```pRS``` computation (same as 1D case)
- Speedup over previous optimisations x1.09