### PR TITLE
Fortran iface

### DIFF
--- a/HMMextra0s/DESCRIPTION
+++ b/HMMextra0s/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Hidden Markov Models with Extra Zeros
 Version: 1.0.0
 Imports: mvtnorm, ellipse
 Suggests: HiddenMarkov
-Depends: methods
+Depends: R (>= 3.0.0), methods
 Date: 2018-09-12
 Author: Ting Wang - I am grateful to Jiancang Zhuang for some helpful suggestions and contributions
 Maintainer: Ting Wang <ting.wang@otago.ac.nz>

--- a/HMMextra0s/NAMESPACE
+++ b/HMMextra0s/NAMESPACE
@@ -3,7 +3,7 @@ importFrom("grDevices", "gray")
 importFrom("graphics", "axis", "box", "lines", "par", "plot", "points",
              "polygon", "text")
 importFrom("stats", "pnorm", "rnorm", "runif")
-useDynLib(HMMextra0s,.registration = TRUE)
+useDynLib(HMMextra0s,.registration = TRUE, .fixes = "F_")
 export(hmm0norm)
 export(sim.hmm0norm)
 export(cumdist.hmm0norm)

--- a/HMMextra0s/R/hmm0norm2d.R
+++ b/HMMextra0s/R/hmm0norm2d.R
@@ -53,11 +53,11 @@ hmm0norm2d <- function( R, Z, pie, gamma, mu, sig, delta, tol=1e-6, print.level=
     }else{
       if (!is.double(gamma)) stop("gamma is not double precision")
       memory0 <- rep(as.double(0), m)
-      loop1 <- .Fortran("loop1", m, nn, phi, pRS, gamma, logalpha,
-                        lscale, memory0, PACKAGE="HMMextra0s")
-      logalpha <- loop1[[6]]
+      fwdeqns <- .Fortran(F_fwdeqns, m, nn, phi, pRS, gamma, logalpha,
+                          lscale, memory0)
+      logalpha <- fwdeqns[[6]]
       if (count > 1.5){
-        LLn = loop1[[7]]
+        LLn = fwdeqns[[7]]
         diffL = LLn - LL 
         print(format(LL,digits=12))
         print(format(LLn,digits=12))
@@ -65,7 +65,7 @@ hmm0norm2d <- function( R, Z, pie, gamma, mu, sig, delta, tol=1e-6, print.level=
         if (LLn < LL) stop ('worse likelihood')
         if (diffL <= tol) break
       } 
-      LL <- loop1[[7]]
+      LL <- fwdeqns[[7]]
     }
 #
 ##Scaled backward variable
@@ -84,9 +84,9 @@ hmm0norm2d <- function( R, Z, pie, gamma, mu, sig, delta, tol=1e-6, print.level=
       }
     } else{
         memory0 <- rep(as.double(0), m)
-        loop2 <- .Fortran("loop2", m, nn, phi, pRS, gamma, logbeta,
-                          lscale, memory0, PACKAGE="HMMextra0s")
-        logbeta <- loop2[[6]]
+        bwdeqns <- .Fortran(F_bwdeqns, m, nn, phi, pRS, gamma, logbeta,
+                            lscale, memory0)
+        logbeta <- bwdeqns[[6]]
     }
 #
 ##E-step
@@ -109,8 +109,8 @@ hmm0norm2d <- function( R, Z, pie, gamma, mu, sig, delta, tol=1e-6, print.level=
         w <- array(0.0, c( nn-1, m, m ) )
 # logalpha can contain -Inf values where phi=0; set NAOK=TRUE as the Fortran code
 # will handle such cases safely
-        estep <- .Fortran("estep", m, nn, logalpha, logbeta, LL,
-                          pRS, gamma, v, w, NAOK=TRUE, PACKAGE="HMMextra0s")
+        estep <- .Fortran(F_estep, m, nn, logalpha, logbeta, LL,
+                          pRS, gamma, v, w, NAOK=TRUE)
         v <- estep[[8]]
         w <- estep[[9]]
     }
@@ -134,9 +134,8 @@ hmm0norm2d <- function( R, Z, pie, gamma, mu, sig, delta, tol=1e-6, print.level=
             }
         }
     } else {
-        mstep2d <- .Fortran("mstep2d", n, m, nn, v, Z, R,
-                            hatpie, hatmu, hatsig,
-                            PACKAGE="HMMextra0s")
+        mstep2d <- .Fortran(F_mstep2d, n, m, nn, v, Z, R,
+                            hatpie, hatmu, hatsig)
         hatpie <- mstep2d[[7]]
         hatmu <- mstep2d[[8]]
         hatsig <- mstep2d[[9]]

--- a/HMMextra0s/src/HMMextra0s_init.c
+++ b/HMMextra0s/src/HMMextra0s_init.c
@@ -2,16 +2,12 @@
 #include <stdlib.h> // for NULL
 #include <R_ext/Rdynload.h>
 
-/* FIXME:
-   Check these declarations against the C/Fortran source code.
-*/
-
 /* .Fortran calls */
 extern void F77_NAME(prsloop)(int *m, int *nn, double *pie, double *R, double *mu, double *sig, double *Z, double *pRS);
 
-extern void F77_NAME(loop1)(int *m, int *T, double *phi, double *pRS, double *gamma, double *logalp, double *lscale, double *tmp);
+extern void F77_NAME(fwdeqns)(int *m, int *T, double *phi, double *pRS, double *gamma, double *logalp, double *lscale, double *tmp);
 
-extern void F77_NAME(loop2)(int *m, int *T, double *phi, double *pRS, double *gamma, double *logbet, double *lscale, double *tmp);
+extern void F77_NAME(bwdeqns)(int *m, int *T, double *phi, double *pRS, double *gamma, double *logbet, double *lscale, double *tmp);
 
 extern void F77_NAME(estep)(int *m, int *nn, double *logalpha, double *logbeta, double *ll, double *pRS, double *gamma, double *v, double *w);
 
@@ -21,8 +17,8 @@ extern void F77_NAME(mstep2d)(int *n, int *m, int *nn, double *v, double *Z, dou
 
 static const R_FortranMethodDef FortranEntries[] = {
     {"prsloop", (DL_FUNC) &F77_NAME(prsloop), 8},
-    {"loop1", (DL_FUNC) &F77_NAME(loop1), 8},
-    {"loop2", (DL_FUNC) &F77_NAME(loop2), 8},
+    {"fwdeqns", (DL_FUNC) &F77_NAME(fwdeqns), 8},
+    {"bwdeqns", (DL_FUNC) &F77_NAME(bwdeqns), 8},
     {"estep", (DL_FUNC) &F77_NAME(estep), 9},
     {"mstep1d", (DL_FUNC) &F77_NAME(mstep1d), 9},
     {"mstep2d", (DL_FUNC) &F77_NAME(mstep2d), 9},
@@ -33,4 +29,5 @@ void R_init_HMMextra0s(DllInfo *dll)
 {
     R_registerRoutines(dll, NULL, NULL, FortranEntries, NULL);
     R_useDynamicSymbols(dll, FALSE);
+    R_forceSymbols(dll, TRUE);
 }

--- a/HMMextra0s/src/Makefile.Mahuika
+++ b/HMMextra0s/src/Makefile.Mahuika
@@ -2,15 +2,22 @@
 # Rename this file to "Makefile" when
 # installing this package on Mahuika
 
+# Use gcc for symbol registration code
+CC = gcc
+CFLAGS = -I$(R_INCLUDE_DIR) -fPIC
+
 FC = ifort
 FCFLAGS = -fPIC -Ofast
 LDFLAGS = -shared
 
-HMMextra0s.so : prsloop.o fwdeqns.o bwdeqns.o estep.o mstep.o
+HMMextra0s.so : HMMextra0s_init.o prsloop.o fwdeqns.o bwdeqns.o estep.o mstep.o
 	$(FC) -o $@ $(FCFLAGS) $+ $(LDFLAGS)
 
 %.o : %.f90
 	$(FC) -c $(FCFLAGS) $<
+
+%.o : %.c
+	$(CC) -c $(CFLAGS) $<
 
 clean :
 	rm -f *.o *.so

--- a/HMMextra0s/src/Makefile.Mahuika
+++ b/HMMextra0s/src/Makefile.Mahuika
@@ -6,7 +6,7 @@ FC = ifort
 FCFLAGS = -fPIC -Ofast
 LDFLAGS = -shared
 
-HMMextra0s.so : prsloop.o loop1.o loop2.o estep.o mstep.o
+HMMextra0s.so : prsloop.o fwdeqns.o bwdeqns.o estep.o mstep.o
 	$(FC) -o $@ $(FCFLAGS) $+ $(LDFLAGS)
 
 %.o : %.f90

--- a/HMMextra0s/src/bwdeqns.f90
+++ b/HMMextra0s/src/bwdeqns.f90
@@ -1,4 +1,4 @@
-subroutine loop2(m, T, phi, pRS, gamma, logbet, lscale, tmp)
+subroutine bwdeqns(m, T, phi, pRS, gamma, logbet, lscale, tmp)
     !     second loop (backward eqns) 
     implicit none
     integer, parameter :: r8 = selected_real_kind(15, 307)
@@ -34,7 +34,7 @@ subroutine loop2(m, T, phi, pRS, gamma, logbet, lscale, tmp)
         enddo
         logbet(T,j) = 0.0_r8
     enddo
-end subroutine loop2
+end subroutine bwdeqns
 
 subroutine multi2(m, a, b, c)
     !     a is (m*m) matrix

--- a/HMMextra0s/src/fwdeqns.f90
+++ b/HMMextra0s/src/fwdeqns.f90
@@ -1,4 +1,4 @@
-subroutine loop1(m, T, phi, pRS, gamma, logalp, lscale, tmp)
+subroutine fwdeqns(m, T, phi, pRS, gamma, logalp, lscale, tmp)
     !     first loop (forward eqns)
     implicit none
     integer, parameter :: r8 = selected_real_kind(15, 307)
@@ -32,7 +32,7 @@ subroutine loop1(m, T, phi, pRS, gamma, logalp, lscale, tmp)
             logalp(i,j) = dlog(logalp(i,j)) + lscalearr(i)
         enddo
     enddo
-end subroutine loop1
+end subroutine fwdeqns
 
 subroutine multi1(m, a, b, c)
     !     a is row vector


### PR DESCRIPTION
R-Fortran interface improvements:

- Renamed ```loop1``` to ```fwdeqns```
- Renamed ```loop2``` to ```bwdeqns```
- Use R objects to call Fortran function instead of string (e.g., ```fwdeqns``` instead of ```"fwdeqns"```) - this is recommended by the R developers to improve reliability
- This change requires R >=3.0.0 - added requirement to ```DESCRIPTION```
- Prefix Fortran function objects with "F_" in R (e.g., ```F_fwdeqns``` instead of ```fwdeqns```) - this is recommended by the R developers to avoid accidental name clashes